### PR TITLE
Updated required CMake version.

### DIFF
--- a/ray_pipeline/CMakeLists.txt
+++ b/ray_pipeline/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.19)
 project(vulkan_ray_tracing_minimal_abstraction)
 
 find_package(Vulkan REQUIRED)

--- a/ray_query/CMakeLists.txt
+++ b/ray_query/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.19)
 project(vulkan_ray_tracing_minimal_abstraction)
 
 find_package(Vulkan REQUIRED)


### PR DESCRIPTION
Version 3.19 is required for `Vulkan_GLSLC_EXECUTABLE`. Builds fail on systems with earlier versions.
```
Vulkan::glslc
New in version 3.19.

The GLSLC SPIR-V compiler, if it has been found.
```
https://cmake.org/cmake/help/latest/module/FindVulkan.html