### PR TITLE
Updated cmake_minimum_required version for Vulkan::glslangValidator target

### DIFF
--- a/ray_pipeline/CMakeLists.txt
+++ b/ray_pipeline/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.19)
+cmake_minimum_required (VERSION 3.21)
 project(vulkan_ray_tracing_minimal_abstraction)
 
 find_package(Vulkan REQUIRED)

--- a/ray_query/CMakeLists.txt
+++ b/ray_query/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.19)
+cmake_minimum_required (VERSION 3.21)
 project(vulkan_ray_tracing_minimal_abstraction)
 
 find_package(Vulkan REQUIRED)


### PR DESCRIPTION
#12
https://cmake.org/cmake/help/latest/module/FindVulkan.html

```
Vulkan::glslangValidator
New in version 3.21.

The glslangValidator tool, if found. It is used to compile GLSL and HLSL shaders into SPIR-V.
```